### PR TITLE
fix endless loop in break session

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -123,7 +123,7 @@
         $('#notice').text('Work time');
 
         // Show the start button & hide the pause button
-        that.pauseShow(true);
+        that.pauseShow(false);
 
       } else {
         // Change to break session if a work session finished


### PR DESCRIPTION
The pomodoro clock stays in break session once you finished the first cycle of work and break time. Starting the second cycle will immediately finish the work time and get straight to the break.

The change in this PR fixes this behavior.
